### PR TITLE
Conditionally restrict communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ please.defaults({
     targetOrigin: otherWindowOrigin,
 
     // conditionally restrict communication
-    allowed: function (messageEvent) {
+    sourceOrigin: function (messageEvent) {
       return (/^https?://example.com/.test(messageEvent.origin));
     }
 });
@@ -98,7 +98,7 @@ please(parent, '*.example.com').set('window.location.href', 'http://www.google.c
 
 **defaults** `please.defaults( objectHash )`
 
-Sets the default `targetWindow` to send message to, the `targetOrigin` of that window, and a test for conditions under which communication should be allowed.
+Sets the default `targetWindow` to send message to, the `targetOrigin` of that window, and a test for conditions under which communication should be sourceOrigin.
 
 ```javascript
 please.defaults({
@@ -109,7 +109,7 @@ please.defaults({
     targetOrigin: '*.example.com',
 
     // conditionally restrict communication
-    allowed: function (messageEvent) {
+    sourceOrigin: function (messageEvent) {
       return (/^https?://example.com/.test(messageEvent.origin));
     }
 });

--- a/src/please.js
+++ b/src/please.js
@@ -2,7 +2,7 @@
 var defaults = {
 	targetWindow: window,
 	targetOrigin: '*',
-	allowed: false
+	sourceOrigin: false
 };
 
 /**
@@ -64,8 +64,8 @@ var please_request = function (requestName) {
 
 var please_messageHandler = function (messageEvent) {
 	
-	if ($.isFunction(defaults.allowed)) {
-		if (!defaults.allowed(messageEvent)) {
+	if ($.isFunction(defaults.sourceOrigin)) {
+		if (!defaults.sourceOrigin(messageEvent)) {
 			return;
 		}
 	}

--- a/tests/child.html
+++ b/tests/child.html
@@ -26,16 +26,16 @@
     function errorFunction () {
       throw new Error('something went wrong');
     }
-    function teardownAllowedTest () {
+    function teardownSourceOriginTest () {
       please.defaults({
-        allowed: false
+        sourceOrigin: false
       });
     }
-    function setupAllowedTest () {
+    function setupSourceOriginTest () {
       please.defaults({
-        allowed: function (messageEvent) {
-          if (JSON.parse(messageEvent.data).data[0] === "teardownAllowedTest") {
-            teardownAllowedTest();
+        sourceOrigin: function (messageEvent) {
+          if (JSON.parse(messageEvent.data).data[0] === "teardownSourceOriginTest") {
+            teardownSourceOriginTest();
             return true;
           }
           return false;

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -39,13 +39,13 @@ asyncTest('Overring defaults', function () {
 	});
 });
 
-module('please.defaults.allowed');
+module('please.defaults.sourceOrigin');
 asyncTest('Does not respond to invalid origin', function () {
 	var childFrame = $('#child-frame').get(0);
 
 	runTestOnIframeLoad(function () {
 
-		please(childFrame.contentWindow).call('setupAllowedTest').then(function () {
+		please(childFrame.contentWindow).call('setupSourceOriginTest').then(function () {
 
 			var responded = false;
 
@@ -55,7 +55,7 @@ asyncTest('Does not respond to invalid origin', function () {
 
 			setTimeout(function () {
 
-				please(childFrame.contentWindow).get('teardownAllowedTest').then(function (value) {
+				please(childFrame.contentWindow).get('teardownSourceOriginTest').then(function (value) {
 
 					ok(!responded, "did not respond to request from invalid origin");
 


### PR DESCRIPTION
- if a test function is passed in, only allow communication if the test returns true
- if no test function passed in, behaviour is unchanged
- test function receives messageEvent object as a param
- test case to ensure that allowed function properly restricts communication
- updated readme
