### PR TITLE
make sure errors exist

### DIFF
--- a/src/please.js
+++ b/src/please.js
@@ -648,6 +648,7 @@ Response.prototype = {
 							postSerializedResult();
 						},
 						function(error) {
+							error = error || new Error('Promise rejected without given error');
 							self.data = new please.Error(error);
 							self.success = false;
 							postSerializedResult();


### PR DESCRIPTION
As there is no obligation for Promises to reason about why the it was rejected an error might not be given.
to prevent please.js from exploding an error is created to indicate what happened while keeping everything alive.