### PR TITLE
Replaces deprecated licenses field with new license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,7 @@
   "bugs": {
     "url": "https://github.com/Wingify/pleasejs/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://opensource.org/licenses/MIT"
-    }
-  ],
+  "license":"MIT",
   "keywords": [],
   "devDependencies": {
     "grunt": "~0.4.4",


### PR DESCRIPTION
This fixes the following warning (thrown when doing `npm install`)

```bash
npm WARN please@0.1.10 No license field.
```

Refer to https://docs.npmjs.com/files/package.json#license