### PR TITLE
Add main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A simple PostMessage communication library",
   "version": "0.1.10",
   "homepage": "",
+  "main": "./src/please.js",
   "author": "Wingify",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As stated in NPM documentation of [`main field`](https://docs.npmjs.com/files/package.json#main)

>The main field is a module ID that is the primary entry point to your program. That is, if your package is named foo, and a user installs it, and then does require("foo"), then your main module's exports object will be returned.