### PR TITLE
Fix memory leak

### DIFF
--- a/src/please.js
+++ b/src/please.js
@@ -522,12 +522,14 @@ Request.prototype = {
 	init: function (name) {
 		$.extend(this, $.Deferred());
 
-		this.id = lastRequestId++;
-		this.name = name;
-		this.data = Array.prototype.slice.call(arguments);
 		this.type = 'request';
 
-		requests[this.id] = this;
+        if (name !== null) {
+            this.id = lastRequestId++;
+            this.name = name;
+            this.data = Array.prototype.slice.call(arguments);
+            requests[this.id] = this;
+        }
 	},
 
 	/**


### PR DESCRIPTION
The Request.create creates a new Request object by calling new
Request(), which would trigger another insertion on the array of a
request will a null name, which would never get removed.